### PR TITLE
Criado get_status() para pegar status de um pedido

### DIFF
--- a/python_picpay/__init__.py
+++ b/python_picpay/__init__.py
@@ -15,6 +15,7 @@ class Picpay:
             "Content-Type": "application/json",
             "x-picpay-token": self.token,
         }
+        self.downloader = Downloader()
 
     def payment(self, payment_data: dict):
         payment_url = urljoin(PICPAY_DEFAULT_URL, "payments")
@@ -24,3 +25,8 @@ class Picpay:
         )
 
         return response
+
+    def get_status(self, referenceId: str):
+        status_url = urljoin(PICPAY_DEFAULT_URL, f"payments/{referenceId}/status")
+
+        return self.downloader.get(status_url, headers=self.headers)

--- a/python_picpay/download.py
+++ b/python_picpay/download.py
@@ -1,37 +1,21 @@
 import requests
-from collections import namedtuple
-
-Response = namedtuple("Response", "referenceId paymentUrl expiresAt qrcode status_code")
-ResponseErrror = namedtuple("ResponseError", "message errors status_code")
 
 
 class Downloader:
     def __init__(self):
         self.session = requests.Session()
 
+    def get(self, url, params=None, cookies=None):
+        return self.session.get(url, params=params, verify=False, cookies=cookies)
+
     def post(self, url, data=None, params=None, cookies=None, headers=None):
-        response = self.session.post(
+        return self.session.post(
             url,
             data=data,
             params=params,
             verify=True,
             headers=headers,
             cookies=cookies,
-        )
-
-        if response.status_code == 200:
-            return Response(
-                referenceId=response.json()["referenceId"],
-                paymentUrl=response.json()["paymentUrl"],
-                expiresAt=response.json()["expiresAt"],
-                qrcode=response.json()["qrcode"],
-                status_code=response.status_code,
-            )
-
-        return ResponseErrror(
-            message=response.json()["message"],
-            errors=response.json().get("errors", {}),
-            status_code=response.status_code,
         )
 
     def close(self):

--- a/python_picpay/download.py
+++ b/python_picpay/download.py
@@ -6,7 +6,9 @@ class Downloader:
         self.session = requests.Session()
 
     def get(self, url, params=None, cookies=None, headers=None):
-        return self.session.get(url, params=params, verify=False, cookies=cookies, headers=headers)
+        return self.session.get(
+            url, params=params, verify=False, cookies=cookies, headers=headers
+        )
 
     def post(self, url, data=None, params=None, cookies=None, headers=None):
         return self.session.post(

--- a/python_picpay/download.py
+++ b/python_picpay/download.py
@@ -5,8 +5,8 @@ class Downloader:
     def __init__(self):
         self.session = requests.Session()
 
-    def get(self, url, params=None, cookies=None):
-        return self.session.get(url, params=params, verify=False, cookies=cookies)
+    def get(self, url, params=None, cookies=None, headers=None):
+        return self.session.get(url, params=params, verify=False, cookies=cookies, headers=headers)
 
     def post(self, url, data=None, params=None, cookies=None, headers=None):
         return self.session.post(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -10,3 +10,12 @@ def load_json_file(name: str):
 @pytest.fixture(scope="module")
 def payment_result():
     return load_json_file("payment_result")
+
+
+@pytest.fixture(scope="module")
+def get_status_result():
+    return {
+        "referenceId": "11111",
+        "status": "refunded",
+        "authorizationId": "5c8e4c711c7e4c8d21b1",
+    }

--- a/tests/snapshots/snap_test_python_picpay.py
+++ b/tests/snapshots/snap_test_python_picpay.py
@@ -16,3 +16,9 @@ snapshots['test_payment 1'] = {
     },
     'referenceId': '4878711'
 }
+
+snapshots['test_get_status 1'] = {
+    'authorizationId': '5c8e4c711c7e4c8d21b1',
+    'referenceId': '11111',
+    'status': 'refunded'
+}

--- a/tests/test_python_picpay.py
+++ b/tests/test_python_picpay.py
@@ -24,10 +24,10 @@ def test_payment(mock_downloader, payment_result, snapshot):
     }
     token = "some things..."
 
-    mock_downloader.return_value.post.return_value = mock.Mock(result=payment_result)
+    mock_downloader.return_value.post.return_value = mock.Mock(json=payment_result)
 
     # get payment...
     picpay = Picpay(token)
     response = picpay.payment(data_mock)
 
-    snapshot.assert_match(response.result)
+    snapshot.assert_match(response.json)

--- a/tests/test_python_picpay.py
+++ b/tests/test_python_picpay.py
@@ -31,3 +31,17 @@ def test_payment(mock_downloader, payment_result, snapshot):
     response = picpay.payment(data_mock)
 
     snapshot.assert_match(response.json)
+
+
+@mock.patch("python_picpay.Downloader")
+def test_get_status(mock_downloader, get_status_result, snapshot):
+    referenceId = "11111"
+    token = "some things..."
+
+    mock_downloader.return_value.get.return_value = mock.Mock(json=get_status_result)
+
+    # get status of payment...
+    picpay = Picpay(token)
+    response = picpay.get_status(referenceId)
+
+    snapshot.assert_match(response.json)


### PR DESCRIPTION
O método get_status foi criado para retorna um status do pedido segundo a documentação oficial do picpay.

Este pr foi criado para solucionar o problema da Issue #4  